### PR TITLE
Modify url in get request for Heroku deployment

### DIFF
--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -26,7 +26,7 @@ class App extends React.Component {
 
   componentDidMount() {
     let updatedPurchases = [];
-    axios.get('http://localhost:3000/purchases/1')
+    axios.get('/purchases/1')
       .then((purchases) => {
         this.setState({stockSummary: purchases.data.stockSummary});
         


### PR DESCRIPTION
This PR modifies the url for the get request to the server to just be to the purchases/1 endpoint rather than specifying the localhost port.