### PR TITLE
Use pool for connections to fix bug with server crashing on heroku

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1,6 +1,7 @@
 var mysql = require('mysql');
 
-var connection = mysql.createConnection({
+var connection = mysql.createPool({
+  connectionLimit: 20,
   host     : process.env.DB_HOST || 'localhost',
   user     : process.env.DB_USERNAME || 'root',
   password : process.env.DB_PASSWORD || '',


### PR DESCRIPTION
Server on heroku is intermittently crashing when connections are not closed. Using pool option to manage this.